### PR TITLE
Report standard error of coefficients

### DIFF
--- a/mrfitty/__main__.py
+++ b/mrfitty/__main__.py
@@ -53,7 +53,10 @@ def fit(args):
             config.get("output", "plots_pdf_dir", fallback=None)
         )
         if not os.path.exists(plots_pdf_file_dir):
-            log.info('output directory "%s" will be created', os.path.abspath(plots_pdf_file_dir))
+            log.info(
+                'output directory "%s" will be created',
+                os.path.abspath(plots_pdf_file_dir),
+            )
             os.makedirs(plots_pdf_file_dir)
         fitter.fit_all(plots_pdf_dp=plots_pdf_file_dir)
     except ConfigurationFileError as e:

--- a/mrfitty/base.py
+++ b/mrfitty/base.py
@@ -458,6 +458,7 @@ class SpectrumFit:
         unknown_spectrum,
         reference_spectra_seq,
         reference_spectra_coef_x,
+        reference_spectra_coef_std_err=None,
     ):
         # log = logging.getLogger(name=self.__class__.__name__)
         self.interpolant_incident_energy = interpolant_incident_energy
@@ -470,6 +471,7 @@ class SpectrumFit:
         # self.unknown_spectrum_b = unknown_spectrum_b.norm
         self.unknown_spectrum_b = unknown_spectrum.data_df.norm
         self.reference_spectra_coef_x = reference_spectra_coef_x
+        self.reference_spectra_coef_std_err = reference_spectra_coef_std_err
         self.fit_spectrum_b = reference_spectra_A_df.dot(reference_spectra_coef_x)
         self.residuals = self.fit_spectrum_b - self.unknown_spectrum_b
         # log.debug('self.unknown_spectrum_b :\n%s', self.unknown_spectrum_b)
@@ -528,6 +530,16 @@ class SpectrumFit:
         ) * self.residuals_auc
         log.debug("residuals_contribution: %s", self.residuals_contribution)
         return self.reference_contribution_percent_sr
+
+    def get_reference_std_err_percent_sr(self):
+        if self.reference_spectra_coef_std_err is None:
+            return None
+        std_err_pct = (
+            self.reference_spectra_coef_std_err
+            * np.sum(np.abs(self.reference_spectra_A_df), axis=0)
+            * (100.0 / self.unknown_spectrum_auc)
+        )
+        return pd.Series(data=std_err_pct, index=self.reference_spectra_A_df.columns)
 
     def get_reference_only_contributions_sr(self):
         # calculate reference-only contributions as well
@@ -701,9 +713,9 @@ class PRM:
             log.warning("{} appears more than once in prm".format(reference_file_path))
         else:
             self.reference_file_path_list.append(reference_file_path)
-            self.reference_file_path_to_mineral_category[
-                reference_file_path
-            ] = mineral_category
+            self.reference_file_path_to_mineral_category[reference_file_path] = (
+                mineral_category
+            )
 
     def get_reference_count(self):
         return len(self.reference_file_path_list)

--- a/mrfitty/combination_fit.py
+++ b/mrfitty/combination_fit.py
@@ -65,7 +65,7 @@ class AllCombinationFitTask:
         energy_range_builder,
         best_fits_plot_limit,
         component_count_range=range(4),
-        **kwargs
+        **kwargs,
     ):
         self.ls = ls
         self.reference_spectrum_list = reference_spectrum_list
@@ -434,6 +434,7 @@ class AllCombinationFitTask:
             raise FitFailed(msg)
         else:
             reference_spectra_coef_x = lm.coef_
+            reference_spectra_coef_std_err = getattr(lm, "std_err_", None)
 
             spectrum_fit = SpectrumFit(
                 interpolant_incident_energy=interpolated_reference_spectra_subset_df.index,
@@ -441,6 +442,7 @@ class AllCombinationFitTask:
                 unknown_spectrum=interpolated_data["unknown_subset_spectrum"],
                 reference_spectra_seq=reference_spectra_subset,
                 reference_spectra_coef_x=reference_spectra_coef_x,
+                reference_spectra_coef_std_err=reference_spectra_coef_std_err,
             )
             return spectrum_fit
 
@@ -485,26 +487,42 @@ class AllCombinationFitTask:
         table_file_dir_path, _ = os.path.split(table_file_path)
         os.makedirs(table_file_dir_path, exist_ok=True)
 
+        first_best_fit = next(iter(self.fit_table.values())).best_fit
+        has_std_err = first_best_fit.reference_spectra_coef_std_err is not None
+
         with open(table_file_path, "wt") as table_file:
-            table_file.write(
-                "spectrum\tNSS\tresidual percent\treference 1\tpercent 1\treference 2\tpercent 2\treference 3\tpercent 3\n"  # noqa
-            )
+            if has_std_err:
+                table_file.write(
+                    "spectrum\tNSS\tresidual percent\t"
+                    "reference 1\tpercent 1\tstd err 1\t"
+                    "reference 2\tpercent 2\tstd err 2\t"
+                    "reference 3\tpercent 3\tstd err 3\n"
+                )
+            else:
+                table_file.write(
+                    "spectrum\tNSS\tresidual percent\t"
+                    "reference 1\tpercent 1\t"
+                    "reference 2\tpercent 2\t"
+                    "reference 3\tpercent 3\n"
+                )
             for spectrum, fit_results in self.fit_table.items():
+                best_fit = fit_results.best_fit
                 table_file.write(spectrum.file_name)
                 table_file.write("\t")
-                table_file.write("{:8.5f}\t".format(fit_results.best_fit.nss))
-                table_file.write(
-                    "{:5.3f}".format(fit_results.best_fit.residuals_contribution)
-                )
+                table_file.write("{:8.5f}\t".format(best_fit.nss))
+                table_file.write("{:5.3f}".format(best_fit.residuals_contribution))
+                std_err_pct_sr = best_fit.get_reference_std_err_percent_sr()
                 for (
                     ref_name,
                     ref_pct,
-                ) in fit_results.best_fit.reference_contribution_percent_sr.sort_values(
+                ) in best_fit.reference_contribution_percent_sr.sort_values(
                     ascending=False
                 ).items():
                     table_file.write("\t")
                     table_file.write(ref_name)
                     table_file.write("\t{:5.3f}".format(ref_pct))
+                    if std_err_pct_sr is not None:
+                        table_file.write("\t{:5.3f}".format(std_err_pct_sr[ref_name]))
                 table_file.write("\n")
 
     def plot_top_fits(self, spectrum, fit_results):
@@ -596,7 +614,9 @@ class AllCombinationFitTask:
         log = logging.getLogger(name=self.__class__.__name__)
         for spectrum, fit_results in self.fit_table.items():
             file_base_name, file_name_ext = os.path.splitext(spectrum.file_name)
-            fit_file_path = os.path.abspath(os.path.join(best_fit_dir_path, file_base_name + "_fit.txt"))
+            fit_file_path = os.path.abspath(
+                os.path.join(best_fit_dir_path, file_base_name + "_fit.txt")
+            )
             log.info("writing best fit to {}".format(fit_file_path))
 
             fit_df = pd.DataFrame(

--- a/mrfitty/fit_task_builder.py
+++ b/mrfitty/fit_task_builder.py
@@ -15,7 +15,7 @@ from mrfitty.base import (
 )
 from mrfitty.prediction_error_fit import PredictionErrorFitTask
 from mrfitty.combination_fit import AllCombinationFitTask
-from mrfitty.linear_model import NonNegativeLinearRegression
+from mrfitty.linear_model import NonNegativeLinearRegression, OlsWithStats
 
 
 class ConfigurationFileError(ValueError):
@@ -207,10 +207,13 @@ def get_fit_parameters_from_config_file(config, prm_max_cmp, prm_min_cmp):
             fit_method_class = LinearRegression
         elif config_fit_method == "nnlsq":
             fit_method_class = NonNegativeLinearRegression
+        elif config_fit_method == "ols":
+            fit_method_class = OlsWithStats
         else:
             raise ConfigurationFileError(
                 'Unrecognized fit_method "{}" in section [fit]. '
-                "Use lsq for least-squares or nnlsq for non-negative least squares.".format(
+                "Use lsq for least-squares, nnlsq for non-negative least squares, "
+                "or ols for ordinary least-squares with fit statistics.".format(
                     config_fit_method
                 )
             )

--- a/mrfitty/linear_model.py
+++ b/mrfitty/linear_model.py
@@ -1,4 +1,5 @@
 import numpy as np
+import statsmodels.api as sm
 from scipy.optimize import nnls
 
 
@@ -9,6 +10,32 @@ class NonNegativeLinearRegression:
 
     def fit(self, X, y):
         self.coef_, self.residual, *extra = nnls(X, y)
+        return self
+
+    def predict(self, A):
+        return np.dot(A, self.coef_)
+
+
+class OlsWithStats:
+    """Ordinary least-squares via statsmodels, exposing coefficient statistics."""
+
+    def __init__(self):
+        self.coef_ = None
+        self.residual = None
+        self.std_err_ = None
+        self.t_values_ = None
+        self.p_values_ = None
+        self.rsquared_ = None
+        self._result = None
+
+    def fit(self, X, y):
+        self._result = sm.OLS(y, X).fit()
+        self.coef_ = self._result.params
+        self.residual = self._result.ssr
+        self.std_err_ = self._result.bse
+        self.t_values_ = self._result.tvalues
+        self.p_values_ = self._result.pvalues
+        self.rsquared_ = self._result.rsquared
         return self
 
     def predict(self, A):

--- a/mrfitty/plot.py
+++ b/mrfitty/plot.py
@@ -20,16 +20,16 @@ def plot_fit(spectrum, any_given_fit, title, fit_quality_labels):
     reference_only_contributions_percent_sr = (
         any_given_fit.get_reference_only_contributions_sr()
     )
+    std_err_percent_sr = any_given_fit.get_reference_std_err_percent_sr()
     longest_name_len = max(
         [len(name) for name in reference_contributions_percent_sr.index]
         + [len(spectrum.file_name)]
     )
+    pad = longest_name_len + 4
     # the format string should look like '{:N}{:5.2f} ({:5.2f})' where N is the length
     #   of the longest reference name
-    reference_contribution_format_str = (
-        "{:" + str(longest_name_len + 4) + "}{:5.2f} ({:5.2f})"
-    )
-    residuals_contribution_format_str = "{:" + str(longest_name_len + 4) + "}{:5.2f}"
+    reference_contribution_format_str = "{:" + str(pad) + "}{:5.2f} ({:5.2f})"
+    residuals_contribution_format_str = "{:" + str(pad) + "}{:5.2f}"
 
     # add fits in descending order of reference contribution
     reference_line_list = []
@@ -46,9 +46,13 @@ def plot_fit(spectrum, any_given_fit, title, fit_quality_labels):
         log.debug(
             "reference-only contribution %s %5.2f", ref_only_name, ref_only_contrib
         )
-        reference_label = reference_contribution_format_str.format(
-            ref_name, ref_contrib, ref_only_contrib
-        )
+        if std_err_percent_sr is not None:
+            ref_err = std_err_percent_sr[ref_name]
+            reference_label = f"{ref_name:{pad}}{ref_contrib:5.2f}±{ref_err:5.2f} ({ref_only_contrib:5.2f})"
+        else:
+            reference_label = reference_contribution_format_str.format(
+                ref_name, ref_contrib, ref_only_contrib
+            )
         reference_label_list.append(reference_label)
 
         # plot once for each reference just to build the legend
@@ -146,12 +150,14 @@ def plot_stacked_fit(spectrum, any_given_fit, title, fit_quality_labels):
     # log.info(any_given_fit.fit_spectrum_b.shape)
 
     reference_contributions_percent_sr = any_given_fit.get_reference_contributions_sr()
+    std_err_percent_sr = any_given_fit.get_reference_std_err_percent_sr()
     longest_name_len = max(
         [len(name) for name in reference_contributions_percent_sr.index]
         + [len(spectrum.file_name)]
     )
+    pad = longest_name_len + 4
     # the format string should look like '{:N}{:5.2f}' where N is the length of the longest reference name
-    contribution_format_str = "{:" + str(longest_name_len + 4) + "}{:5.2f}"
+    contribution_format_str = "{:" + str(pad) + "}{:5.2f}"
 
     # log.info(any_given_fit.residuals.shape)
     residuals_label = contribution_format_str.format(
@@ -183,7 +189,12 @@ def plot_stacked_fit(spectrum, any_given_fit, title, fit_quality_labels):
     reference_contributions_percent_sr.sort_values(ascending=False)
     for name, value in reference_contributions_percent_sr.items():
         log.debug("reference component {} {}".format(name, value))
-        reference_label = contribution_format_str.format(name, value)
+        if std_err_percent_sr is not None:
+            reference_label = (
+                f"{name:{pad}}{value:5.2f}±{std_err_percent_sr[name]:5.2f}"
+            )
+        else:
+            reference_label = contribution_format_str.format(name, value)
         reference_label_list.append(reference_label)
 
     reference_line_list = ax.stackplot(

--- a/mrfitty/prediction_error_fit.py
+++ b/mrfitty/prediction_error_fit.py
@@ -195,9 +195,9 @@ class PredictionErrorFitTask(AllCombinationFitTask):
                 component_count_i
             ][0]
 
-            component_count_to_median_cp[
-                component_count_i
-            ] = best_fit_for_component_count.median_C_p
+            component_count_to_median_cp[component_count_i] = (
+                best_fit_for_component_count.median_C_p
+            )
             component_count_to_median_cp_ci_lo_hi[component_count_i] = (
                 best_fit_for_component_count.median_C_p_ci_lo,
                 best_fit_for_component_count.median_C_p_ci_hi,

--- a/mrfitty/tests/conftest.py
+++ b/mrfitty/tests/conftest.py
@@ -37,5 +37,3 @@ def arsenic_unknowns(arsenic_example_path):
     ]
 
     return unknown_spectrum_list
-
-

--- a/mrfitty/tests/test_combination_fit.py
+++ b/mrfitty/tests/test_combination_fit.py
@@ -1,6 +1,68 @@
+import os
+import tempfile
+
+import pytest
+from sklearn.linear_model import LinearRegression
+
+from mrfitty.base import AdaptiveEnergyRangeBuilder
+from mrfitty.combination_fit import AllCombinationFitTask
+from mrfitty.linear_model import NonNegativeLinearRegression, OlsWithStats
+
+
 def test_fit_with_fixed_energy_range(tmpdir):
     pass
 
 
 def test_fit():
     pass
+
+
+def _make_task(ls, arsenic_references, arsenic_unknowns):
+    unknown = next(s for s in arsenic_unknowns if s.file_name == "OTT3_55_spot0.e")
+    task = AllCombinationFitTask(
+        ls=ls,
+        energy_range_builder=AdaptiveEnergyRangeBuilder(),
+        reference_spectrum_list=arsenic_references,
+        unknown_spectrum_list=[unknown],
+        best_fits_plot_limit=0,
+        component_count_range=range(1, 3 + 1),
+    )
+    with tempfile.TemporaryDirectory() as plots_pdf_dp:
+        task.fit_all(plots_pdf_dp=plots_pdf_dp)
+    return task, unknown
+
+
+def test_write_table_without_std_err(tmp_path, arsenic_references, arsenic_unknowns):
+    task, unknown = _make_task(
+        NonNegativeLinearRegression, arsenic_references, arsenic_unknowns
+    )
+    table_path = str(tmp_path / "out" / "table.tsv")
+    task.write_table(table_path)
+
+    with open(table_path) as f:
+        content = f.read()
+
+    assert "std err" not in content
+    header_line = content.splitlines()[0]
+    assert "percent 1" in header_line
+    assert "percent 2" in header_line
+
+
+def test_write_table_with_std_err(tmp_path, arsenic_references, arsenic_unknowns):
+    task, unknown = _make_task(OlsWithStats, arsenic_references, arsenic_unknowns)
+    table_path = str(tmp_path / "out" / "table.tsv")
+    task.write_table(table_path)
+
+    with open(table_path) as f:
+        lines = f.readlines()
+
+    header = lines[0]
+    assert "std err 1" in header
+    assert "std err 2" in header
+
+    data_line = lines[1]
+    cols = data_line.strip().split("\t")
+    # spectrum, NSS, residual %, ref1, pct1, stderr1, [ref2, pct2, stderr2, ...]
+    assert len(cols) >= 6
+    # std err value should be a parseable float
+    float(cols[5])

--- a/mrfitty/tests/test_fit_task_builder.py
+++ b/mrfitty/tests/test_fit_task_builder.py
@@ -41,15 +41,13 @@ def test__get_required_config_value():
 
 def test_build_reference_spectrum_list_from_prm_section(fs):
     reference_config = get_config_parser()
-    reference_config.read_string(
-        """\
+    reference_config.read_string("""\
 [prm]
 NBCompoMax = 4
 NBCompoMin = 1
 arsenate_aqueous_avg_als_cal.e
 arsenate_sorbed_anth_avg_als_cal.e
-"""
-    )
+""")
 
     fs.create_file(
         file_path="arsenate_aqueous_avg_als_cal.e", contents=_spectrum_file_content
@@ -71,15 +69,13 @@ arsenate_sorbed_anth_avg_als_cal.e
 
 def test_build_reference_spectrum_list_from_prm_section__bad_component_counts(fs):
     reference_config = get_config_parser()
-    reference_config.read_string(
-        """\
+    reference_config.read_string("""\
 [prm]
 NBCompoMax = 1
 NBCompoMin = 4
 arsenate_aqueous_avg_als_cal.e
 arsenate_sorbed_anth_avg_als_cal.e
-"""
-    )
+""")
 
     fs.create_file(
         file_path="arsenate_aqueous_avg_als_cal.e", contents=_spectrum_file_content
@@ -94,12 +90,10 @@ arsenate_sorbed_anth_avg_als_cal.e
 
 def test_build_reference_spectrum_list_from_config_file(fs):
     reference_config = get_config_parser()
-    reference_config.read_string(
-        """\
+    reference_config.read_string("""\
 [references]
 references/*.e
-"""
-    )
+""")
 
     fs.create_dir(directory_path="references")
     fs.create_file(
@@ -118,12 +112,10 @@ references/*.e
 
 def test_build_unknown_spectrum_list_from_config_file(fs):
     data_config = get_config_parser()
-    data_config.read_string(
-        """\
+    data_config.read_string("""\
 [data]
 data/*.e
-"""
-    )
+""")
 
     fs.create_dir(directory_path="data")
     fs.create_file(file_path="data/data_0.e", contents=_spectrum_file_content)
@@ -136,13 +128,11 @@ data/*.e
 
 def test_get_fit_parameters_from_config_file():
     fit_config = get_config_parser()
-    fit_config.read_string(
-        """\
+    fit_config.read_string("""\
 [fit]
 max_component_count = 3
 min_component_count = 1
-"""
-    )
+""")
 
     (
         max_cmp,
@@ -158,14 +148,12 @@ min_component_count = 1
 
 def test_get_good_fit_parameter_bootstrap_count_from_config_file():
     fit_config = get_config_parser()
-    fit_config.read_string(
-        """\
+    fit_config.read_string("""\
 [fit]
 max_component_count = 3
 min_component_count = 1
 bootstrap_count = 2000
-"""
-    )
+""")
 
     (
         max_cmp,
@@ -181,14 +169,12 @@ bootstrap_count = 2000
 
 def test_get_bad_fit_parameter_bootstrap_count_from_config_file():
     fit_config = get_config_parser()
-    fit_config.read_string(
-        """\
+    fit_config.read_string("""\
 [fit]
 max_component_count = 3
 min_component_count = 1
 bootstrap_count = haha
-"""
-    )
+""")
 
     with pytest.raises(ConfigurationFileError):
         (
@@ -204,27 +190,41 @@ bootstrap_count = haha
 
 def test_fit_method_lsq():
     fit_config = get_config_parser()
-    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = lsq\n")
-    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)
+    fit_config.read_string(
+        "[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = lsq\n"
+    )
+    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(
+        fit_config, prm_max_cmp=3, prm_min_cmp=1
+    )
     assert fit_method_class is LinearRegression
 
 
 def test_fit_method_nnlsq():
     fit_config = get_config_parser()
-    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = nnlsq\n")
-    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)
+    fit_config.read_string(
+        "[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = nnlsq\n"
+    )
+    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(
+        fit_config, prm_max_cmp=3, prm_min_cmp=1
+    )
     assert fit_method_class is NonNegativeLinearRegression
 
 
 def test_fit_method_ols():
     fit_config = get_config_parser()
-    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = ols\n")
-    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)
+    fit_config.read_string(
+        "[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = ols\n"
+    )
+    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(
+        fit_config, prm_max_cmp=3, prm_min_cmp=1
+    )
     assert fit_method_class is OlsWithStats
 
 
 def test_fit_method_unknown_raises():
     fit_config = get_config_parser()
-    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = bad\n")
+    fit_config.read_string(
+        "[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = bad\n"
+    )
     with pytest.raises(ConfigurationFileError):
         get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)

--- a/mrfitty/tests/test_fit_task_builder.py
+++ b/mrfitty/tests/test_fit_task_builder.py
@@ -1,5 +1,7 @@
 import pytest
 
+from sklearn.linear_model import LinearRegression
+
 from mrfitty.fit_task_builder import (
     build_reference_spectrum_list_from_config_file,
     build_reference_spectrum_list_from_config_prm_section,
@@ -9,6 +11,7 @@ from mrfitty.fit_task_builder import (
     get_fit_parameters_from_config_file,
     _get_required_config_value,
 )
+from mrfitty.linear_model import NonNegativeLinearRegression, OlsWithStats
 
 _spectrum_file_content = """\
   11825.550       0.62757215E-02   0.62429776E-02  -0.58947170E-03
@@ -197,3 +200,31 @@ bootstrap_count = haha
         ) = get_fit_parameters_from_config_file(
             fit_config, prm_max_cmp=3, prm_min_cmp=1
         )
+
+
+def test_fit_method_lsq():
+    fit_config = get_config_parser()
+    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = lsq\n")
+    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)
+    assert fit_method_class is LinearRegression
+
+
+def test_fit_method_nnlsq():
+    fit_config = get_config_parser()
+    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = nnlsq\n")
+    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)
+    assert fit_method_class is NonNegativeLinearRegression
+
+
+def test_fit_method_ols():
+    fit_config = get_config_parser()
+    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = ols\n")
+    _, _, fit_method_class, _, _ = get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)
+    assert fit_method_class is OlsWithStats
+
+
+def test_fit_method_unknown_raises():
+    fit_config = get_config_parser()
+    fit_config.read_string("[fit]\nmax_component_count = 3\nmin_component_count = 1\nfit_method = bad\n")
+    with pytest.raises(ConfigurationFileError):
+        get_fit_parameters_from_config_file(fit_config, prm_max_cmp=3, prm_min_cmp=1)

--- a/mrfitty/tests/test_linear_model.py
+++ b/mrfitty/tests/test_linear_model.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+from mrfitty.linear_model import OlsWithStats
+
+
+@pytest.fixture
+def synthetic_data():
+    rng = np.random.default_rng(42)
+    n_samples, n_features = 100, 3
+    true_coef = np.array([0.5, 0.3, 0.2])
+    X = rng.random((n_samples, n_features))
+    y = X @ true_coef + rng.normal(0, 0.01, n_samples)
+    return X, y, true_coef
+
+
+def test_ols_with_stats_fit_coef(synthetic_data):
+    X, y, true_coef = synthetic_data
+    model = OlsWithStats().fit(X, y)
+    np.testing.assert_allclose(model.coef_, true_coef, atol=0.05)
+
+
+def test_ols_with_stats_std_err(synthetic_data):
+    X, y, _ = synthetic_data
+    model = OlsWithStats().fit(X, y)
+    assert model.std_err_ is not None
+    assert len(model.std_err_) == X.shape[1]
+    assert all(model.std_err_ >= 0)
+
+
+def test_ols_with_stats_statistics_populated(synthetic_data):
+    X, y, _ = synthetic_data
+    model = OlsWithStats().fit(X, y)
+    assert model.t_values_ is not None and len(model.t_values_) == X.shape[1]
+    assert model.p_values_ is not None and len(model.p_values_) == X.shape[1]
+    assert model.rsquared_ is not None
+    assert 0.0 <= model.rsquared_ <= 1.0
+
+
+def test_ols_with_stats_predict(synthetic_data):
+    X, y, _ = synthetic_data
+    model = OlsWithStats().fit(X, y)
+    np.testing.assert_allclose(model.predict(X), X @ model.coef_)
+
+
+def test_ols_with_stats_residual(synthetic_data):
+    X, y, _ = synthetic_data
+    model = OlsWithStats().fit(X, y)
+    assert model.residual >= 0.0
+
+
+def test_ols_with_stats_fit_returns_self(synthetic_data):
+    X, y, _ = synthetic_data
+    model = OlsWithStats()
+    assert model.fit(X, y) is model

--- a/mrfitty/tests/test_permute_row_elements.py
+++ b/mrfitty/tests/test_permute_row_elements.py
@@ -38,10 +38,12 @@ def test_columns_preserved():
 
 def test_row_values_are_permutation_of_input():
     """Each output row is a rearrangement of the corresponding input row."""
-    df = _make_df([
-        [1.0, 2.0, 3.0, 4.0],
-        [10.0, 20.0, 30.0, 40.0],
-    ])
+    df = _make_df(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [10.0, 20.0, 30.0, 40.0],
+        ]
+    )
     result = AllCombinationFitTask.permute_row_elements(df.copy())
     for i in range(df.shape[0]):
         assert sorted(result.iloc[i, :]) == sorted(df.iloc[i, :])
@@ -77,7 +79,9 @@ def test_rows_shuffled_independently():
         if list(result.iloc[0, :]) != list(result.iloc[1, :]):
             seen_different = True
             break
-    assert seen_different, "rows always received the same permutation — shuffles are not independent"
+    assert (
+        seen_different
+    ), "rows always received the same permutation — shuffles are not independent"
 
 
 # --- shuffle is actually random ---

--- a/mrfitty/tests/test_spectrum.py
+++ b/mrfitty/tests/test_spectrum.py
@@ -10,13 +10,11 @@ class TestSpectrum:
     def test_read_file_with_one_column(self, tmpdir):
         # generate a test file
         a_file = tmpdir.join("test_read_file.e")
-        a_file.write(
-            """
+        a_file.write("""
 1000.0
 1001.0
 1002.0
-"""
-        )
+""")
         a_file_path = str(a_file)
         with pytest.raises(Exception):
             base.Spectrum.read_file(a_file_path)
@@ -24,13 +22,11 @@ class TestSpectrum:
     def test_read_file_with_zero_comments(self, tmpdir):
         # generate a test file
         a_file = tmpdir.join("test_read_file.e")
-        a_file.write(
-            """
+        a_file.write("""
 1000.0\t0.123
 1001.0\t0.234
 1002.0\t0.345
-"""
-        )
+""")
         a_file_path = str(a_file)
         a_spectrum = base.Spectrum.read_file(a_file_path)
 
@@ -39,14 +35,12 @@ class TestSpectrum:
     def test_read_file_with_one_comment(self, tmpdir):
         # generate a test file
         a_file = tmpdir.join("test_read_file.e")
-        a_file.write(
-            """
+        a_file.write("""
 # comments
 1000.0\t0.123
 1001.0\t0.234
 1002.0\t0.345
-"""
-        )
+""")
         a_file_path = str(a_file)
         a_spectrum = base.Spectrum.read_file(a_file_path)
 
@@ -55,15 +49,13 @@ class TestSpectrum:
     def test_read_file_with_two_comments(self, tmpdir):
         # generate a test file
         a_file = tmpdir.join("test_read_file.e")
-        a_file.write(
-            """
+        a_file.write("""
 # comments
 # more comments
 1000.0\t0.123
 1001.0\t0.234
 1002.0\t0.345
-"""
-        )
+""")
         a_file_path = str(a_file)
         a_spectrum = base.Spectrum.read_file(a_file_path)
 
@@ -72,14 +64,12 @@ class TestSpectrum:
     def test_read_file_with_three_columns(self, tmpdir):
         # generate a test file
         a_file = tmpdir.join("test_read_file.e")
-        a_file.write(
-            """
+        a_file.write("""
 # comments
 1000.0\t0.123\t0.012
 1001.0\t0.234\t0.023
 1002.0\t0.345\t0.034
-"""
-        )
+""")
         a_file_path = str(a_file)
         a_spectrum = base.Spectrum.read_file(a_file_path)
 
@@ -95,8 +85,7 @@ class TestSpectrum:
 
 
 def test_parse_header():
-    header = io.StringIO(
-        """
+    header = io.StringIO("""
 # Valence group: Fe3_silicate
 # Athena data file -- Athena version 0.8.056
 # Saving Aegirine as normalized mu(E)
@@ -137,8 +126,7 @@ def test_parse_header():
 #  energy norm bkg_norm der_norm
   7010.6674       0.10203199E-02   0.10202176E-02  -0.17394430E-05
   7015.6673       0.10110155E-02   0.10109131E-02  -0.22488155E-04
-"""
-    )
+""")
 
     a_spectrum = base.Spectrum.read_file(header)
 

--- a/mrfitty/tests/test_spectrum_fit.py
+++ b/mrfitty/tests/test_spectrum_fit.py
@@ -1,12 +1,55 @@
+import numpy as np
+import pandas as pd
 from sklearn.linear_model import LinearRegression
 
-from mrfitty.base import AdaptiveEnergyRangeBuilder
+from mrfitty.base import AdaptiveEnergyRangeBuilder, ReferenceSpectrum, Spectrum
 from mrfitty.combination_fit import AllCombinationFitTask
+from mrfitty.linear_model import NonNegativeLinearRegression, OlsWithStats
+
+
+def _make_synthetic_spectra():
+    energies = np.linspace(11800, 11900, 50)
+    ref_a_norm = np.sin(energies / 100)
+    ref_b_norm = np.cos(energies / 100)
+
+    ref_a_df = pd.DataFrame(
+        {"norm": ref_a_norm}, index=pd.Index(energies, name="energy")
+    )
+    ref_b_df = pd.DataFrame(
+        {"norm": ref_b_norm}, index=pd.Index(energies, name="energy")
+    )
+    ref_a = ReferenceSpectrum("ref_a.e", ref_a_df, {})
+    ref_b = ReferenceSpectrum("ref_b.e", ref_b_df, {})
+
+    coef = np.array([0.6, 0.4])
+    unknown_norm = (
+        coef[0] * ref_a_norm
+        + coef[1] * ref_b_norm
+        + np.random.default_rng(0).normal(0, 0.001, 50)
+    )
+    unknown_df = pd.DataFrame(
+        {"norm": unknown_norm}, index=pd.Index(energies, name="energy")
+    )
+    unknown = Spectrum("unknown.e", unknown_df, {})
+
+    return [ref_a, ref_b], unknown
+
+
+def _fit_spectrum(ls, reference_spectra, unknown):
+    fitter = AllCombinationFitTask(
+        ls=ls,
+        reference_spectrum_list=reference_spectra,
+        unknown_spectrum_list=(unknown,),
+        energy_range_builder=AdaptiveEnergyRangeBuilder(),
+        best_fits_plot_limit=0,
+        component_count_range=(2,),
+    )
+    spectrum_fit, _ = fitter.fit(unknown_spectrum=unknown)
+    return spectrum_fit
 
 
 def generate_spectrum_fit(reference_count, reference_spectra, unknown_spectrum):
     """
-
     Parameters
     ----------
     reference_count: (int) count of reference spectra used in SpectrumFit
@@ -15,18 +58,55 @@ def generate_spectrum_fit(reference_count, reference_spectra, unknown_spectrum):
     -------
     SpectrumFit instance
     """
-
-    energy_range_builder = AdaptiveEnergyRangeBuilder()
-
     fitter = AllCombinationFitTask(
         ls=LinearRegression,
         reference_spectrum_list=reference_spectra,
         unknown_spectrum_list=(unknown_spectrum,),
-        energy_range_builder=energy_range_builder,
+        energy_range_builder=AdaptiveEnergyRangeBuilder(),
         best_fits_plot_limit=0,
         component_count_range=(reference_count,),
     )
-
     spectrum_fit, _ = fitter.fit(unknown_spectrum=unknown_spectrum)
-
     return spectrum_fit
+
+
+def test_get_reference_std_err_percent_sr_returns_none_when_no_std_err():
+    reference_spectra, unknown = _make_synthetic_spectra()
+    sf = _fit_spectrum(NonNegativeLinearRegression, reference_spectra, unknown)
+    assert sf is not None
+    assert sf.get_reference_std_err_percent_sr() is None
+    coef_sr = pd.Series(
+        sf.reference_spectra_coef_x, index=sf.reference_spectra_A_df.columns
+    )
+    np.testing.assert_allclose(coef_sr["ref_a.e"], 0.6, atol=0.05)
+    np.testing.assert_allclose(coef_sr["ref_b.e"], 0.4, atol=0.05)
+
+
+def test_get_reference_std_err_percent_sr_returns_series():
+    reference_spectra, unknown = _make_synthetic_spectra()
+    sf = _fit_spectrum(OlsWithStats, reference_spectra, unknown)
+    assert sf is not None
+    coef_sr = pd.Series(
+        sf.reference_spectra_coef_x, index=sf.reference_spectra_A_df.columns
+    )
+    np.testing.assert_allclose(coef_sr["ref_a.e"], 0.6, atol=0.05)
+    np.testing.assert_allclose(coef_sr["ref_b.e"], 0.4, atol=0.05)
+    result = sf.get_reference_std_err_percent_sr()
+
+    assert result is not None
+    assert isinstance(result, pd.Series)
+    assert len(result) == 2
+    assert list(result.index) == list(sf.reference_spectra_A_df.columns)
+    assert all(result >= 0)
+
+
+def test_linear_regression_fit_coefficients():
+    reference_spectra, unknown = _make_synthetic_spectra()
+    sf = _fit_spectrum(LinearRegression, reference_spectra, unknown)
+    assert sf is not None
+    assert sf.get_reference_std_err_percent_sr() is None
+    coef_sr = pd.Series(
+        sf.reference_spectra_coef_x, index=sf.reference_spectra_A_df.columns
+    )
+    np.testing.assert_allclose(coef_sr["ref_a.e"], 0.6, atol=0.05)
+    np.testing.assert_allclose(coef_sr["ref_b.e"], 0.4, atol=0.05)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pandas
 scipy
 scikits.bootstrap
 scikit-learn
-sqlalchemy
+statsmodels


### PR DESCRIPTION
A new fit method "ols" has been added. This method calculates and reports the standard error of the coefficients as a percentage of each reference in plot legends and in the fit table (file). Specify "ols" as the fit method in configuration files:

```
[fit]
...
fit_method = ols
```